### PR TITLE
エラーメッセージでライブ終了している事が判断できる様に書式を変更。

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -25,7 +25,7 @@ export function getOptionsFromLivePage(data: string): FetchOptions & { liveId: s
 
   const replayResult = data.match(/['"]isReplay['"]:\s*(true)/)
   if (replayResult) {
-    throw new Error(`${liveId} is finished live`)
+    throw new Error(`Live Stream was finished. LIVE_ID:${liveId}`)
   }
 
   let apiKey: string
@@ -49,7 +49,7 @@ export function getOptionsFromLivePage(data: string): FetchOptions & { liveId: s
   if (continuationResult) {
     continuation = continuationResult[1]
   } else {
-    throw new Error("Continuation was not found")
+    throw new Error("Live Stream was finished. Continuation was not found")
   }
 
   return {
@@ -64,6 +64,9 @@ export function getOptionsFromLivePage(data: string): FetchOptions & { liveId: s
 /** get_live_chat レスポンスを変換 */
 export function parseChatData(data: GetLiveChatResponse): [ChatItem[], string] {
   let chatItems: ChatItem[] = []
+  if (data.continuationContents === undefined) {
+    throw new Error("Live Stream was finished. No continuation contents.")
+  }
   if (data.continuationContents.liveChatContinuation.actions) {
     chatItems = data.continuationContents.liveChatContinuation.actions
       .map((v) => parseActionToChatItem(v))

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -389,7 +389,7 @@ describe("Parser", () => {
 
     test("Replay (Finished)", () => {
       const res = readFileSync(__dirname + "/testdata/replay_page.html").toString()
-      expect(() => getOptionsFromLivePage(res)).toThrow("is finished live")
+      expect(() => getOptionsFromLivePage(res)).toThrow("Live Stream was finished")
     })
 
     test("No such Live", () => {


### PR DESCRIPTION
ライブ終了後にアクセスした場合や、ライブ視聴から終了した場合などで、ライブ終了時のエラーが異なるため、メッセージの冒頭を`Live Stream was finished.` で統一する事で、エラーハンドリングする利用者側が共通の処理が行いやすくなる様に変更。